### PR TITLE
Add multi-exchange streaming pipeline and mini chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Grok's K.O.C. mini demo
+
+This repository contains a minimal proof of concept demonstrating
+ccxt.pro WebSocket aggregation and a matplotlib-based mini-chart.
+
+## Usage
+
+```
+python -m pip install -r requirements.txt
+python -m src.main
+```
+
+The example streams ``BTC/USDT`` candles from multiple exchanges and
+renders their close prices in a small chart.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+ccxt>=4.3.0
+ccxt-pro>=2.6.45
+loguru>=0.7.2
+matplotlib>=3.9.0
+pandas>=2.2.2
+pytest>=8.3.2

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# Grok's K.O.C. package

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -1,0 +1,66 @@
+"""Data pipeline with ccxt.pro multi-exchange streaming.
+
+This module exposes :class:`DataPipeline` which can watch OHLCV candles
+from multiple exchanges concurrently using ``ccxt.pro`` WebSockets.
+Incoming candles are placed into a standard :class:`queue.Queue` for
+consumption by other parts of the application such as the GUI.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import queue
+from typing import Dict, List, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import ccxt.pro as ccxtpro
+except Exception:  # fallback stub for environments without ccxt.pro
+    class ccxtpro:  # type: ignore
+        pass
+
+logger = logging.getLogger(__name__)
+
+
+class DataPipeline:
+    """Stream OHLCV data from multiple exchanges."""
+
+    def __init__(self, exchanges: List[str], symbol: str, timeframe: str = "1m") -> None:
+        self.exchanges = exchanges
+        self.symbol = symbol
+        self.timeframe = timeframe
+        self.data_queue: "queue.Queue[Tuple[str, list]]" = queue.Queue()
+        self._clients: Dict[str, object] = {}
+
+    async def _get_client(self, name: str) -> object:
+        """Return a cached ccxt.pro client for ``name``."""
+        if name not in self._clients:
+            logger.debug("initializing ccxt.pro client for %s", name)
+            exchange_class = getattr(ccxtpro, name)
+            self._clients[name] = exchange_class()
+        return self._clients[name]
+
+    async def _watch_ohlcv(self, name: str) -> None:
+        """Internal task to stream candles for ``name``."""
+        client = await self._get_client(name)
+        while True:
+            try:
+                candles = await client.watch_ohlcv(self.symbol, self.timeframe)
+                if candles:
+                    self.data_queue.put((name, candles[-1]))
+                    logger.debug("streamed candle from %s", name)
+            except Exception as exc:  # pragma: no cover - network errors
+                logger.warning("stream error from %s: %s", name, exc)
+                await asyncio.sleep(5)
+
+    async def stream(self) -> None:
+        """Start streaming on all configured exchanges."""
+        await asyncio.gather(*(self._watch_ohlcv(name) for name in self.exchanges))
+
+    async def close(self) -> None:
+        """Close all open ccxt.pro clients."""
+        for client in self._clients.values():
+            try:
+                await client.close()
+            except Exception:
+                pass
+        self._clients.clear()

--- a/src/interface.py
+++ b/src/interface.py
@@ -1,0 +1,50 @@
+"""Minimal GUI showing aggregated OHLCV data in a mini-chart.
+
+The :class:`MiniChart` class consumes data from :class:`DataPipeline` and
+renders the last close price from multiple exchanges using matplotlib.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Tuple
+
+import matplotlib
+matplotlib.use("Agg")  # use non-interactive backend for safety
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
+import pandas as pd
+
+from .data_pipeline import DataPipeline
+
+
+class MiniChart:
+    """Display aggregated close prices from multiple exchanges."""
+
+    def __init__(self, pipeline: DataPipeline) -> None:
+        self.pipeline = pipeline
+        self.df = pd.DataFrame()
+        self.fig, self.ax = plt.subplots(figsize=(5, 3))
+
+    def start(self) -> None:
+        """Start the data pipeline and render the chart."""
+        thread = threading.Thread(target=lambda: asyncio.run(self.pipeline.stream()), daemon=True)
+        thread.start()
+        self.ani = FuncAnimation(self.fig, self._update, interval=1000)
+        plt.show()
+
+    def _update(self, _frame: int) -> None:
+        q = self.pipeline.data_queue
+        updated = False
+        while not q.empty():
+            exchange, candle = q.get()
+            ts, _o, _h, _l, close, _v = candle
+            idx = pd.to_datetime(ts, unit="ms")
+            self.df.loc[idx, exchange] = close
+            updated = True
+        if updated:
+            self.ax.clear()
+            self.df.plot(ax=self.ax)
+            self.ax.set_xlabel("time")
+            self.ax.set_ylabel("close")
+            self.ax.set_title(self.pipeline.symbol)

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,15 @@
+"""Example entry point demonstrating the mini-chart with aggregated streams."""
+from __future__ import annotations
+
+from .data_pipeline import DataPipeline
+from .interface import MiniChart
+
+
+def main() -> None:
+    pipeline = DataPipeline(["binance", "kraken"], "BTC/USDT")
+    chart = MiniChart(pipeline)
+    chart.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -1,0 +1,43 @@
+import asyncio
+import types
+import pytest
+import sys
+from pathlib import Path
+
+# Ensure src package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import data_pipeline as dp_mod
+
+# Provide stub ccxt.pro if missing
+if not hasattr(dp_mod, "ccxtpro"):
+    dp_mod.ccxtpro = types.SimpleNamespace()
+
+DataPipeline = dp_mod.DataPipeline
+
+
+class DummyExchange:
+    def __init__(self):
+        self.id = "dummy"
+
+    async def watch_ohlcv(self, symbol, timeframe):
+        await asyncio.sleep(0)
+        return [[0, 1, 2, 3, 4, 5]]
+
+    async def close(self):
+        pass
+
+
+def test_multi_exchange_stream(monkeypatch):
+    monkeypatch.setattr(dp_mod.ccxtpro, "dummy", DummyExchange, raising=False)
+    dp = DataPipeline(["dummy"], "BTC/USDT")
+
+    async def run_once():
+        task = asyncio.create_task(dp._watch_ohlcv("dummy"))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run_once())
+    assert not dp.data_queue.empty()


### PR DESCRIPTION
## Summary
- Add DataPipeline to aggregate OHLCV candles from multiple ccxt.pro exchanges into a shared queue
- Provide MiniChart interface that renders aggregated close prices using matplotlib
- Include unit test covering the multi-exchange streaming logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfbd0184f48324982a88b2ad396af2